### PR TITLE
Use compile_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2022-05-11
+
+### Fixed
+- Fixed descouraged use warning
+
 ## 1.0.0 - 2022-05-11
 
 This release represents stability in the API. There is no functional change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.1 - 2022-05-11
+## 1.0.1 - 2022-09-22
 
 ### Fixed
 - Fixed descouraged use warning

--- a/lib/beeline/honeycomb.ex
+++ b/lib/beeline/honeycomb.ex
@@ -33,7 +33,7 @@ defmodule Beeline.Honeycomb do
 
   use Task
 
-  @sender Application.get_env(
+  @sender Application.compile_env(
             :beeline_honeycomb,
             :honeycomb_sender,
             Opencensus.Honeycomb.Sender


### PR DESCRIPTION
Fixes discouraged usage warning:

```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/beeline/honeycomb.ex:36: Beeline.Honeycomb
```